### PR TITLE
WIP: Updating requirements wrt. conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,11 @@ matplotlib==3.7.1
 numpy==1.25.2
 pandas==2.0.3
 Pillow==9.4.0
-Pillow==10.0.0
 pytorch_lightning==2.0.7
-scikit_learn==1.3.0
+scikit-learn==1.3.0
 seaborn==0.12.2
-skimage==0.0
+scikit-image==0.21.0
 torch==2.0.1
 torchmetrics==0.11.4
-torchvision==0.15.2a0
+torchvision==0.15.2
 tqdm==4.65.0


### PR DESCRIPTION
- Conflicting versions of `Pillow` was included
- `skimage` is a dummy package for `scikit-image`
- `torchvision== 0.15.2a0` is not available on pypi